### PR TITLE
Gemspec - removed unnecessary dependency on `rails` gem

### DIFF
--- a/pinterest_reporter.gemspec
+++ b/pinterest_reporter.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rails",   '>=3.2.12'
   spec.add_dependency "faraday"
   spec.add_dependency "capybara"
   spec.add_dependency "nokogiri"


### PR DESCRIPTION
Gemspec - removed unnecessary dependency on `rails` gem
